### PR TITLE
Update to OWSLib 0.29.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requirements = [
 
 test_requirements = [
     'pytest', 'pytest_cov', 'pytest_localserver',
-    'owslib<0.28.1',  # OWSLib is broken from here to at least 0.29.1 - should be fixed in 0.29.2
+    'owslib>0.29.2',
     'pytest_mock', 'pep8',
     'pytest-helpers-namespace', 'flask-cors',
     'fsspec',


### PR DESCRIPTION
This fixes CVE-2023-27476.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview datacube-ows end -->